### PR TITLE
Continue the game after finishing

### DIFF
--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -324,13 +324,9 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
-			inputPaths = (
-			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/lib/features/games/dos/bloc/dos_bloc.dart
+++ b/lib/features/games/dos/bloc/dos_bloc.dart
@@ -30,6 +30,9 @@ class DosBloc extends Bloc<DosEvent, DosState> {
     on<StartNewGame>(_onStartNewGame);
     on<ReturnToMenu>(_onReturnToMenu);
     on<CheckGameEnd>(_onCheckGameEnd);
+    on<ContinueGame>(_onContinueGame);
+    on<FinishGame>(_onFinishGame);
+    on<MarkGameEndModalShown>(_onMarkGameEndModalShown);
     on<SaveGameSession>(_onSaveGameSession);
   }
 
@@ -338,7 +341,8 @@ class DosBloc extends Bloc<DosEvent, DosState> {
         }
       }
 
-      if (gameEnded) {
+      // Only set gameEnded to true if we haven't shown the modal yet
+      if (gameEnded && !currentState.hasShownGameEndModal) {
         emit(currentState.copyWith(gameEnded: true));
 
         add(DeleteSavedGame());
@@ -399,6 +403,7 @@ class DosBloc extends Bloc<DosEvent, DosState> {
         playerRedoStack: playerRedoStack,
         currentPlayerIndex: 0,
         gameEnded: false,
+        hasShownGameEndModal: false,
       ));
 
       add(DeleteSavedGame());
@@ -436,6 +441,36 @@ class DosBloc extends Bloc<DosEvent, DosState> {
 
     // Just emit initial state, navigation will be handled in the UI
     emit(DosInitial());
+  }
+
+  void _onContinueGame(
+    ContinueGame event,
+    Emitter<DosState> emit,
+  ) {
+    if (state is DosGameState) {
+      final currentState = state as DosGameState;
+      emit(currentState.copyWith(gameEnded: false));
+    }
+  }
+
+  void _onFinishGame(
+    FinishGame event,
+    Emitter<DosState> emit,
+  ) {
+    if (state is DosGameState) {
+      final currentState = state as DosGameState;
+      emit(currentState.copyWith(gameEnded: true));
+    }
+  }
+
+  void _onMarkGameEndModalShown(
+    MarkGameEndModalShown event,
+    Emitter<DosState> emit,
+  ) {
+    if (state is DosGameState) {
+      final currentState = state as DosGameState;
+      emit(currentState.copyWith(hasShownGameEndModal: true));
+    }
   }
 
   // Helper methods for working with state
@@ -499,5 +534,20 @@ class DosBloc extends Bloc<DosEvent, DosState> {
 
   void deleteSavedGame() {
     add(DeleteSavedGame());
+  }
+
+  // Continue the game after reaching score limit
+  void continueGame() {
+    add(ContinueGame());
+  }
+
+  // Finish the game manually
+  void finishGame() {
+    add(FinishGame());
+  }
+
+  // Mark that the game end modal has been shown
+  void markGameEndModalShown() {
+    add(MarkGameEndModalShown());
   }
 }

--- a/lib/features/games/dos/bloc/dos_event.dart
+++ b/lib/features/games/dos/bloc/dos_event.dart
@@ -75,3 +75,9 @@ class StartNewGame extends DosEvent {}
 class ReturnToMenu extends DosEvent {}
 
 class CheckGameEnd extends DosEvent {}
+
+class ContinueGame extends DosEvent {}
+
+class FinishGame extends DosEvent {}
+
+class MarkGameEndModalShown extends DosEvent {}

--- a/lib/features/games/dos/bloc/dos_state.dart
+++ b/lib/features/games/dos/bloc/dos_state.dart
@@ -47,6 +47,7 @@ final class DosGameState extends DosState {
   final int lastScoreChange;
   final bool isScoreChanging;
   final bool gameEnded;
+  final bool hasShownGameEndModal;
 
   DosGameState({
     required this.players,
@@ -58,6 +59,7 @@ final class DosGameState extends DosState {
     this.lastScoreChange = 0,
     this.isScoreChanging = false,
     this.gameEnded = false,
+    this.hasShownGameEndModal = false,
   })  : playerScoreHistory = playerScoreHistory ?? {},
         playerRedoStack = playerRedoStack ?? {};
 
@@ -71,6 +73,7 @@ final class DosGameState extends DosState {
     int? lastScoreChange,
     bool? isScoreChanging,
     bool? gameEnded,
+    bool? hasShownGameEndModal,
   }) {
     return DosGameState(
       players: players ?? this.players,
@@ -82,6 +85,7 @@ final class DosGameState extends DosState {
       lastScoreChange: lastScoreChange ?? this.lastScoreChange,
       isScoreChanging: isScoreChanging ?? this.isScoreChanging,
       gameEnded: gameEnded ?? this.gameEnded,
+      hasShownGameEndModal: hasShownGameEndModal ?? this.hasShownGameEndModal,
     );
   }
 

--- a/lib/features/games/uno/bloc/uno_bloc.dart
+++ b/lib/features/games/uno/bloc/uno_bloc.dart
@@ -30,6 +30,9 @@ class UnoBloc extends Bloc<UnoEvent, UnoState> {
     on<StartNewGame>(_onStartNewGame);
     on<ReturnToMenu>(_onReturnToMenu);
     on<CheckGameEnd>(_onCheckGameEnd);
+    on<ContinueGame>(_onContinueGame);
+    on<FinishGame>(_onFinishGame);
+    on<MarkGameEndModalShown>(_onMarkGameEndModalShown);
     on<SaveGameSession>(_onSaveGameSession);
   }
 
@@ -344,7 +347,8 @@ class UnoBloc extends Bloc<UnoEvent, UnoState> {
         }
       }
 
-      if (gameEnded) {
+      // Only set gameEnded to true if we haven't shown the modal yet
+      if (gameEnded && !currentState.hasShownGameEndModal) {
         emit(currentState.copyWith(gameEnded: true));
 
         // Delete saved game when a game ends
@@ -408,6 +412,7 @@ class UnoBloc extends Bloc<UnoEvent, UnoState> {
         playerRedoStack: playerRedoStack,
         currentPlayerIndex: 0,
         gameEnded: false,
+        hasShownGameEndModal: false,
       ));
 
       // Delete the saved game session when starting a new game
@@ -448,6 +453,36 @@ class UnoBloc extends Bloc<UnoEvent, UnoState> {
 
     // Just emit initial state, navigation will be handled in the UI
     emit(UnoInitial());
+  }
+
+  void _onContinueGame(
+    ContinueGame event,
+    Emitter<UnoState> emit,
+  ) {
+    if (state is UnoGameState) {
+      final currentState = state as UnoGameState;
+      emit(currentState.copyWith(gameEnded: false));
+    }
+  }
+
+  void _onFinishGame(
+    FinishGame event,
+    Emitter<UnoState> emit,
+  ) {
+    if (state is UnoGameState) {
+      final currentState = state as UnoGameState;
+      emit(currentState.copyWith(gameEnded: true));
+    }
+  }
+
+  void _onMarkGameEndModalShown(
+    MarkGameEndModalShown event,
+    Emitter<UnoState> emit,
+  ) {
+    if (state is UnoGameState) {
+      final currentState = state as UnoGameState;
+      emit(currentState.copyWith(hasShownGameEndModal: true));
+    }
   }
 
   // Helper methods for working with state
@@ -513,5 +548,20 @@ class UnoBloc extends Bloc<UnoEvent, UnoState> {
   // Delete the saved game
   void deleteSavedGame() {
     add(DeleteSavedGame());
+  }
+
+  // Continue the game after reaching score limit
+  void continueGame() {
+    add(ContinueGame());
+  }
+
+  // Finish the game manually
+  void finishGame() {
+    add(FinishGame());
+  }
+
+  // Mark that the game end modal has been shown
+  void markGameEndModalShown() {
+    add(MarkGameEndModalShown());
   }
 }

--- a/lib/features/games/uno/bloc/uno_event.dart
+++ b/lib/features/games/uno/bloc/uno_event.dart
@@ -76,3 +76,9 @@ class StartNewGame extends UnoEvent {}
 class ReturnToMenu extends UnoEvent {}
 
 class CheckGameEnd extends UnoEvent {}
+
+class ContinueGame extends UnoEvent {}
+
+class FinishGame extends UnoEvent {}
+
+class MarkGameEndModalShown extends UnoEvent {}

--- a/lib/features/games/uno/bloc/uno_state.dart
+++ b/lib/features/games/uno/bloc/uno_state.dart
@@ -47,6 +47,7 @@ final class UnoGameState extends UnoState {
   final int lastScoreChange;
   final bool isScoreChanging;
   final bool gameEnded;
+  final bool hasShownGameEndModal;
 
   UnoGameState({
     required this.players,
@@ -58,6 +59,7 @@ final class UnoGameState extends UnoState {
     this.lastScoreChange = 0,
     this.isScoreChanging = false,
     this.gameEnded = false,
+    this.hasShownGameEndModal = false,
   })  : playerScoreHistory = playerScoreHistory ?? {},
         playerRedoStack = playerRedoStack ?? {};
 
@@ -71,6 +73,7 @@ final class UnoGameState extends UnoState {
     int? lastScoreChange,
     bool? isScoreChanging,
     bool? gameEnded,
+    bool? hasShownGameEndModal,
   }) {
     return UnoGameState(
       players: players ?? this.players,
@@ -82,6 +85,7 @@ final class UnoGameState extends UnoState {
       lastScoreChange: lastScoreChange ?? this.lastScoreChange,
       isScoreChanging: isScoreChanging ?? this.isScoreChanging,
       gameEnded: gameEnded ?? this.gameEnded,
+      hasShownGameEndModal: hasShownGameEndModal ?? this.hasShownGameEndModal,
     );
   }
 

--- a/lib/features/games/uno_flip/bloc/uno_flip_bloc.dart
+++ b/lib/features/games/uno_flip/bloc/uno_flip_bloc.dart
@@ -30,6 +30,9 @@ class UnoFlipBloc extends Bloc<UnoFlipEvent, UnoFlipState> {
     on<StartNewGame>(_onStartNewGame);
     on<ReturnToMenu>(_onReturnToMenu);
     on<CheckGameEnd>(_onCheckGameEnd);
+    on<ContinueGame>(_onContinueGame);
+    on<FinishGame>(_onFinishGame);
+    on<MarkGameEndModalShown>(_onMarkGameEndModalShown);
     on<SaveGameSession>(_onSaveGameSession);
   }
 
@@ -338,7 +341,8 @@ class UnoFlipBloc extends Bloc<UnoFlipEvent, UnoFlipState> {
         }
       }
 
-      if (gameEnded) {
+      // Only set gameEnded to true if we haven't shown the modal yet
+      if (gameEnded && !currentState.hasShownGameEndModal) {
         emit(currentState.copyWith(gameEnded: true));
 
         add(DeleteSavedGame());
@@ -399,6 +403,7 @@ class UnoFlipBloc extends Bloc<UnoFlipEvent, UnoFlipState> {
         playerRedoStack: playerRedoStack,
         currentPlayerIndex: 0,
         gameEnded: false,
+        hasShownGameEndModal: false,
       ));
 
       add(DeleteSavedGame());
@@ -436,6 +441,36 @@ class UnoFlipBloc extends Bloc<UnoFlipEvent, UnoFlipState> {
 
     // Just emit initial state, navigation will be handled in the UI
     emit(UnoFlipInitial());
+  }
+
+  void _onContinueGame(
+    ContinueGame event,
+    Emitter<UnoFlipState> emit,
+  ) {
+    if (state is UnoFlipGameState) {
+      final currentState = state as UnoFlipGameState;
+      emit(currentState.copyWith(gameEnded: false));
+    }
+  }
+
+  void _onFinishGame(
+    FinishGame event,
+    Emitter<UnoFlipState> emit,
+  ) {
+    if (state is UnoFlipGameState) {
+      final currentState = state as UnoFlipGameState;
+      emit(currentState.copyWith(gameEnded: true));
+    }
+  }
+
+  void _onMarkGameEndModalShown(
+    MarkGameEndModalShown event,
+    Emitter<UnoFlipState> emit,
+  ) {
+    if (state is UnoFlipGameState) {
+      final currentState = state as UnoFlipGameState;
+      emit(currentState.copyWith(hasShownGameEndModal: true));
+    }
   }
 
   // Helper methods for working with state
@@ -499,5 +534,20 @@ class UnoFlipBloc extends Bloc<UnoFlipEvent, UnoFlipState> {
 
   void deleteSavedGame() {
     add(DeleteSavedGame());
+  }
+
+  // Continue the game after reaching score limit
+  void continueGame() {
+    add(ContinueGame());
+  }
+
+  // Finish the game manually
+  void finishGame() {
+    add(FinishGame());
+  }
+
+  // Mark that the game end modal has been shown
+  void markGameEndModalShown() {
+    add(MarkGameEndModalShown());
   }
 }

--- a/lib/features/games/uno_flip/bloc/uno_flip_event.dart
+++ b/lib/features/games/uno_flip/bloc/uno_flip_event.dart
@@ -76,3 +76,9 @@ class StartNewGame extends UnoFlipEvent {}
 class ReturnToMenu extends UnoFlipEvent {}
 
 class CheckGameEnd extends UnoFlipEvent {}
+
+class ContinueGame extends UnoFlipEvent {}
+
+class FinishGame extends UnoFlipEvent {}
+
+class MarkGameEndModalShown extends UnoFlipEvent {}

--- a/lib/features/games/uno_flip/bloc/uno_flip_state.dart
+++ b/lib/features/games/uno_flip/bloc/uno_flip_state.dart
@@ -47,6 +47,7 @@ final class UnoFlipGameState extends UnoFlipState {
   final int lastScoreChange;
   final bool isScoreChanging;
   final bool gameEnded;
+  final bool hasShownGameEndModal;
 
   UnoFlipGameState({
     required this.players,
@@ -58,6 +59,7 @@ final class UnoFlipGameState extends UnoFlipState {
     this.lastScoreChange = 0,
     this.isScoreChanging = false,
     this.gameEnded = false,
+    this.hasShownGameEndModal = false,
   })  : playerScoreHistory = playerScoreHistory ?? {},
         playerRedoStack = playerRedoStack ?? {};
 
@@ -71,6 +73,7 @@ final class UnoFlipGameState extends UnoFlipState {
     int? lastScoreChange,
     bool? isScoreChanging,
     bool? gameEnded,
+    bool? hasShownGameEndModal,
   }) {
     return UnoFlipGameState(
       players: players ?? this.players,
@@ -82,6 +85,7 @@ final class UnoFlipGameState extends UnoFlipState {
       lastScoreChange: lastScoreChange ?? this.lastScoreChange,
       isScoreChanging: isScoreChanging ?? this.isScoreChanging,
       gameEnded: gameEnded ?? this.gameEnded,
+      hasShownGameEndModal: hasShownGameEndModal ?? this.hasShownGameEndModal,
     );
   }
 

--- a/lib/generated/intl/messages_de.dart
+++ b/lib/generated/intl/messages_de.dart
@@ -86,6 +86,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "cleric": MessageLookupByLibrary.simpleMessage("kleriker"),
     "close": MessageLookupByLibrary.simpleMessage("schließen"),
     "common": MessageLookupByLibrary.simpleMessage("zähler"),
+    "continueGame": MessageLookupByLibrary.simpleMessage("spiel fortsetzen"),
     "continueTitle": MessageLookupByLibrary.simpleMessage("fortsetzen"),
     "couldNotLaunch": MessageLookupByLibrary.simpleMessage(
       "konnte nicht starten",

--- a/lib/generated/intl/messages_en.dart
+++ b/lib/generated/intl/messages_en.dart
@@ -82,6 +82,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "cleric": MessageLookupByLibrary.simpleMessage("cleric"),
     "close": MessageLookupByLibrary.simpleMessage("close"),
     "common": MessageLookupByLibrary.simpleMessage("counter"),
+    "continueGame": MessageLookupByLibrary.simpleMessage("continue game"),
     "continueTitle": MessageLookupByLibrary.simpleMessage("continue"),
     "couldNotLaunch": MessageLookupByLibrary.simpleMessage("could not launch"),
     "cursed": MessageLookupByLibrary.simpleMessage("cursed"),

--- a/lib/generated/intl/messages_es.dart
+++ b/lib/generated/intl/messages_es.dart
@@ -84,6 +84,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "cleric": MessageLookupByLibrary.simpleMessage("clérigo"),
     "close": MessageLookupByLibrary.simpleMessage("cerrar"),
     "common": MessageLookupByLibrary.simpleMessage("contador"),
+    "continueGame": MessageLookupByLibrary.simpleMessage("continuar juego"),
     "continueTitle": MessageLookupByLibrary.simpleMessage("continuar"),
     "couldNotLaunch": MessageLookupByLibrary.simpleMessage(
       "no se pudo iniciar",

--- a/lib/generated/intl/messages_ru.dart
+++ b/lib/generated/intl/messages_ru.dart
@@ -82,6 +82,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "cleric": MessageLookupByLibrary.simpleMessage("клирик"),
     "close": MessageLookupByLibrary.simpleMessage("закрыть"),
     "common": MessageLookupByLibrary.simpleMessage("счетчик"),
+    "continueGame": MessageLookupByLibrary.simpleMessage("продолжить игру"),
     "continueTitle": MessageLookupByLibrary.simpleMessage("продолжить"),
     "couldNotLaunch": MessageLookupByLibrary.simpleMessage(
       "не удалось запустить",

--- a/lib/generated/l10n.dart
+++ b/lib/generated/l10n.dart
@@ -2714,6 +2714,16 @@ class S {
     return Intl.message('game over', name: 'gameOver', desc: '', args: []);
   }
 
+  /// `continue game`
+  String get continueGame {
+    return Intl.message(
+      'continue game',
+      name: 'continueGame',
+      desc: '',
+      args: [],
+    );
+  }
+
   /// `another round`
   String get newGameWithSamePlayers {
     return Intl.message(

--- a/lib/l10n/intl_de.arb
+++ b/lib/l10n/intl_de.arb
@@ -307,6 +307,7 @@
   "theNumberOfPlayersShouldBe": "die anzahl der spieler sollte größer sein als",
   "gameUpTo": "spiel bis: ",
   "gameOver": "spiel beendet",
+  "continueGame": "spiel fortsetzen",
   "newGameWithSamePlayers": "noch eine runde",
   "newGame": "neues spiel",
   "returnToMenu": "zurück zum menü",

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -308,6 +308,7 @@
   "theNumberOfPlayersShouldBe": "the number of players should be more than",
   "gameUpTo": "game up to: ",
   "gameOver": "game over",
+  "continueGame": "continue game",
   "newGameWithSamePlayers": "another round",
   "newGame": "new game",
   "returnToMenu": "return to menu",

--- a/lib/l10n/intl_es.arb
+++ b/lib/l10n/intl_es.arb
@@ -306,6 +306,7 @@
   "theNumberOfPlayersShouldBe": "el número de jugadores debe ser más que",
   "gameUpTo": "juego hasta: ",
   "gameOver": "fin del juego",
+  "continueGame": "continuar juego",
   "newGameWithSamePlayers": "otra ronda",
   "newGame": "nuevo juego",
   "returnToMenu": "volver al menú",

--- a/lib/l10n/intl_fr.arb
+++ b/lib/l10n/intl_fr.arb
@@ -307,6 +307,7 @@
   "thenumberofplayersshouldbe": "le nombre de joueurs doit être plus de",
   "gameupto": "partie jusqu’à : ",
   "gameover": "fin de jeu",
+  "continuegame": "continuer le jeu",
   "newgamewithsameplayers": "nouvelle partie",
   "newgame": "nouveau jeu",
   "returntomenu": "retour au menu",

--- a/lib/l10n/intl_ru.arb
+++ b/lib/l10n/intl_ru.arb
@@ -308,6 +308,7 @@
   "theNumberOfPlayersShouldBe": "количество игроков должно быть больше",
   "gameUpTo": "игра до: ",
   "gameOver": "игра окончена",
+  "continueGame": "продолжить игру",
   "newGameWithSamePlayers": "еще раунд",
   "newGame": "новая игра",
   "returnToMenu": "вернуться в меню",

--- a/lib/shared/widgets/game_widgets/game_end_uno_modal_widget.dart
+++ b/lib/shared/widgets/game_widgets/game_end_uno_modal_widget.dart
@@ -15,6 +15,7 @@ class GameEndUnoModalWidget extends StatelessWidget {
   final VoidCallback onNewGameWithSamePlayers;
   final VoidCallback onNewGame;
   final VoidCallback onReturnToMenu;
+  final VoidCallback onContinueGame;
 
   const GameEndUnoModalWidget({
     super.key,
@@ -24,6 +25,7 @@ class GameEndUnoModalWidget extends StatelessWidget {
     required this.onNewGameWithSamePlayers,
     required this.onNewGame,
     required this.onReturnToMenu,
+    required this.onContinueGame,
   });
 
   @override
@@ -138,6 +140,23 @@ class GameEndUnoModalWidget extends StatelessWidget {
                 mainAxisAlignment: MainAxisAlignment.center,
                 children: [
                   GestureDetector(
+                    onTap: onContinueGame,
+                    child: Padding(
+                      padding: const EdgeInsets.symmetric(vertical: 8.0),
+                      child: TextScramble(
+                          text: S.of(context).continueGame,
+                          builder: (context, scrambledText) {
+                            return Text(
+                              scrambledText,
+                              style: theme.display2.copyWith(
+                                color: theme.redColor,
+                              ),
+                              textAlign: TextAlign.center,
+                            );
+                          }),
+                    ),
+                  ),
+                  GestureDetector(
                     onTap: onNewGameWithSamePlayers,
                     child: Padding(
                       padding: const EdgeInsets.symmetric(vertical: 8.0),
@@ -200,6 +219,7 @@ class GameEndUnoModalWidget extends StatelessWidget {
     required VoidCallback onNewGameWithSamePlayers,
     required VoidCallback onNewGame,
     required VoidCallback onReturnToMenu,
+    required VoidCallback onContinueGame,
   }) {
     HapticFeedback.selectionClick();
 
@@ -225,6 +245,7 @@ class GameEndUnoModalWidget extends StatelessWidget {
                 onNewGameWithSamePlayers: onNewGameWithSamePlayers,
                 onNewGame: onNewGame,
                 onReturnToMenu: onReturnToMenu,
+                onContinueGame: onContinueGame,
               ),
             ),
           ],


### PR DESCRIPTION
## Checklist

### Project

- [x] I am ran the app before creating PR
- [x] The `common_counter` functionality is not covered, so I made a new one

### Change type

- [ ] bugfix
- [ ] new game
- [x] new feature
- [ ] other

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "Continue Game" option to the end-of-game modal for Uno, Uno Flip, and Dos games, allowing players to resume a finished game.
  * The end-of-game modal now appears only once per game end event, improving user experience.
  * Enhanced synchronization between the game state and modal display to prevent repeated modal pop-ups.

* **Localization**
  * Added translations for the "Continue Game" option in English, German, Spanish, French, and Russian.

* **Bug Fixes**
  * Improved handling of game end state to prevent duplicate modal displays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->